### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 2.7, 3.7, 3.8, 3.9 ]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259