### PR TITLE
Fix TypeError() on loading objects after `pickle_compat.unpatch()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## UNRELEASED
+
+- Fix TypeError() on loading objects after `pickle_compat.unpatch()`
+
 ## [2.1.0] - 2020-12-28
 
 Add compatibility with Python 3.7 and 3.9

--- a/pickle_compat/compat.py
+++ b/pickle_compat/compat.py
@@ -57,9 +57,10 @@ else:
 
     # We also need to explicitly register our own handler in the dispatcher, because
     # otherwise a method of the superclass will be called
-    CompatUnpickler.dispatch[  # type: ignore
-        pickle.NEWOBJ
-    ] = CompatUnpickler.load_newobj
+    CompatUnpickler.dispatch = VanillaUnpickler.dispatch.copy()  # type: ignore
+    CompatUnpickler.dispatch[
+        pickle.NEWOBJ  # type: ignore
+    ] = CompatUnpickler.load_newobj  # type: ignore
 
     # Forward-compatible load and loads, nothing is needed to be patched
     compat_load = pickle.load  # type: ignore

--- a/tests/test_pickle_compat.py
+++ b/tests/test_pickle_compat.py
@@ -82,3 +82,14 @@ def test_namedtuple(get_fixture):
 
 def test_dict_subclass(get_fixture):
     assert pickle.loads(get_fixture("dict_subclass")) == {u"foo": 1}
+
+
+class Foo(object):
+    pass
+
+
+def test_loads_after_unpatch():
+    serialized = pickle.dumps(Foo())
+    unpatch()
+    foo = pickle.loads(serialized)
+    assert isinstance(foo, Foo)


### PR DESCRIPTION
We update the superclass' dict when we run
"CompatUnpickler.dispatch[...] = ...".

The fix addresses the issue by copying the dict from the superclass to
CompatUnpickler before modifying it.

Closes #9.